### PR TITLE
feat: use android DataStore Preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ The module will automatically use the appropriate CipherStorage implementation b
 - API level 16-22 will en/de crypt using Facebook Conceal
 - API level 23+ will en/de crypt using Android Keystore
 
-Encrypted data is stored in SharedPreferences.
+Encrypted data is stored in DataStore Preferences.
 
 The `setInternetCredentials(server, username, password)` call will be resolved as call to `setGenericPassword(username, password, server)`. Use the `server` argument to distinguish between multiple entries.
 

--- a/README.md
+++ b/README.md
@@ -507,9 +507,7 @@ This package supports visionOS.
 
 ### Security
 
-On API levels that do not support Android keystore, Facebook Conceal is used to en/decrypt stored data. The encrypted data is then stored in SharedPreferences. Since Conceal itself stores its encryption key in SharedPreferences, it follows that if the device is rooted (or if an attacker can somehow access the filesystem), the key can be obtained and the stored data can be decrypted. Therefore, on such a device, the conceal encryption is only an obscurity. On API level 23+ the key is stored in the Android Keystore, which makes the key non-exportable and therefore makes the entire process more secure. Follow best practices and do not store user credentials on a device. Instead use tokens or other forms of authentication and re-ask for user credentials before performing sensitive operations.
-
-![Android Security Framework](https://source.android.com/security/images/authentication-flow.png)
+On API levels that do not support Android keystore, Facebook Conceal is used to en/decrypt stored data. The encrypted data is then stored in DataStore Preferences. Since Conceal itself stores its encryption key in DataStore Preferences, it follows that if the device is rooted (or if an attacker can somehow access the filesystem), the key can be obtained and the stored data can be decrypted. Therefore, on such a device, the conceal encryption is only an obscurity. On API level 23+ the key is stored in the Android Keystore, which makes the key non-exportable and therefore makes the entire process more secure. Follow best practices and do not store user credentials on a device. Instead use tokens or other forms of authentication and re-ask for user credentials before performing sensitive operations.
 
 - [Android authentication](https://source.android.com/security/authentication)
 - [Android Cipher](https://developer.android.com/guide/topics/security/cryptography)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,7 @@
 buildscript {
+  // Buildscript is evaluated before everything else so we can't use safeExtGet
+  def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : "1.8.0"
+
   repositories {
     maven {
       url "https://plugins.gradle.org/m2/"
@@ -6,8 +9,10 @@ buildscript {
     mavenCentral()
     google()
   }
+
   dependencies {
-    classpath("com.android.tools.build:gradle:8.3.1")
+    classpath "com.android.tools.build:gradle:8.3.1"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }
 }
 
@@ -23,6 +28,7 @@ if (isNewArchitectureEnabled()) {
   apply plugin: "com.facebook.react"
 }
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 repositories {
   google()
@@ -69,12 +75,19 @@ repositories {
   mavenCentral()
 }
 
+def kotlin_version = safeExtGet('kotlinVersion', '1.8.0')
+
 dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-android:+"
 
   implementation 'androidx.appcompat:appcompat:1.6.1'
   implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
+  // Used to store encrypted data
+  implementation("androidx.datastore:datastore-preferences:1.0.0")
 
   // https://mvnrepository.com/artifact/androidx.biometric/biometric
   implementation 'androidx.biometric:biometric:1.1.0@aar'

--- a/android/src/main/java/com/dorianmazur/keychain/DataStorePrefsStorage.kt
+++ b/android/src/main/java/com/dorianmazur/keychain/DataStorePrefsStorage.kt
@@ -1,0 +1,118 @@
+package com.dorianmazur.keychain
+
+import android.content.Context
+import android.util.Base64
+import androidx.datastore.core.DataMigration
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.facebook.react.bridge.ReactApplicationContext
+import com.dorianmazur.keychain.KeychainModule.KnownCiphers
+import com.dorianmazur.keychain.PrefsStorage.KEYCHAIN_DATA
+import com.dorianmazur.keychain.PrefsStorage.ResultSet
+import com.dorianmazur.keychain.PrefsStorage.getKeyForCipherStorage
+import com.dorianmazur.keychain.PrefsStorage.getKeyForPassword
+import com.dorianmazur.keychain.PrefsStorage.getKeyForUsername
+import com.dorianmazur.keychain.PrefsStorage.isKeyForCipherStorage
+import com.dorianmazur.keychain.cipherStorage.CipherStorage
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+
+@Suppress("unused")
+class DataStorePrefsStorage(reactContext: ReactApplicationContext) : PrefsStorage {
+
+  private val Context.prefs: DataStore<Preferences> by preferencesDataStore(
+    name = KEYCHAIN_DATA,
+    produceMigrations = ::sharedPreferencesMigration
+  )
+  private val prefs: DataStore<Preferences> = reactContext.prefs
+  private val prefsData: Preferences get() = callSuspendable { prefs.data.first() }
+
+  private fun sharedPreferencesMigration(context: Context): List<DataMigration<Preferences>> {
+    return listOf(SharedPreferencesMigration(context, KEYCHAIN_DATA))
+  }
+
+  override fun getEncryptedEntry(service: String): ResultSet? {
+    val bytesForUsername = getBytesForUsername(service)
+    val bytesForPassword = getBytesForPassword(service)
+    var cipherStorageName = getCipherStorageName(service)
+
+    // in case of wrong password or username
+    if (bytesForUsername == null || bytesForPassword == null) return null
+    if (cipherStorageName == null) {
+      // If the CipherStorage name is not found, we assume it is because the entry was written by an older
+      // version of this library. The older version used Facebook Conceal, so we default to that.
+      cipherStorageName = KnownCiphers.FB
+    }
+    return ResultSet(cipherStorageName, bytesForUsername, bytesForPassword)
+  }
+
+  override fun removeEntry(service: String) {
+    val keyForUsername = stringPreferencesKey(getKeyForUsername(service))
+    val keyForPassword = stringPreferencesKey(getKeyForPassword(service))
+    val keyForCipherStorage = stringPreferencesKey(getKeyForCipherStorage(service))
+    callSuspendable {
+      prefs.edit {
+        it.remove(keyForUsername)
+        it.remove(keyForPassword)
+        it.remove(keyForCipherStorage)
+      }
+    }
+  }
+
+  override fun storeEncryptedEntry(
+    service: String,
+    encryptionResult: CipherStorage.EncryptionResult,
+  ) {
+    val keyForUsername = stringPreferencesKey(getKeyForUsername(service))
+    val keyForPassword = stringPreferencesKey(getKeyForPassword(service))
+    val keyForCipherStorage = stringPreferencesKey(getKeyForCipherStorage(service))
+    callSuspendable {
+      prefs.edit {
+        it[keyForUsername] = Base64.encodeToString(encryptionResult.username, Base64.DEFAULT)
+        it[keyForPassword] = Base64.encodeToString(encryptionResult.password, Base64.DEFAULT)
+        it[keyForCipherStorage] = encryptionResult.cipherName
+      }
+    }
+  }
+
+  override fun getUsedCipherNames(): Set<String?> {
+    val result: MutableSet<String?> = HashSet()
+    val keys = prefsData.asMap().keys.map { it.name }
+    for (key in keys) {
+      if (isKeyForCipherStorage(key)) {
+        val cipher = prefsData[stringPreferencesKey(key)]
+        result.add(cipher)
+      }
+    }
+    return result
+  }
+
+  private fun <T> callSuspendable(block: suspend () -> T): T {
+    return runBlocking {
+      block()
+    }
+  }
+
+  private fun getBytesForUsername(service: String): ByteArray? {
+    val key = stringPreferencesKey(getKeyForUsername(service))
+    return getBytes(key)
+  }
+
+  private fun getBytesForPassword(service: String): ByteArray? {
+    val key = stringPreferencesKey(getKeyForPassword(service))
+    return getBytes(key)
+  }
+
+  private fun getCipherStorageName(service: String): String? {
+    val key = stringPreferencesKey(getKeyForCipherStorage(service))
+    return prefsData[key]
+  }
+
+  private fun getBytes(prefKey: Preferences.Key<String>): ByteArray? {
+    return prefsData[prefKey]?.let { Base64.decode(it, Base64.DEFAULT) }
+  }
+}

--- a/android/src/main/java/com/dorianmazur/keychain/KeychainModule.java
+++ b/android/src/main/java/com/dorianmazur/keychain/KeychainModule.java
@@ -129,7 +129,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
   //region Members
   /** Name-to-instance lookup  map. */
   private final Map<String, CipherStorage> cipherStorageMap = new HashMap<>();
-  /** Shared preferences storage. */
+  /** Preferences storage. */
   private final PrefsStorage prefsStorage;
   //endregion
 
@@ -138,7 +138,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
   /** Default constructor. */
   public KeychainModule(@NonNull final ReactApplicationContext reactContext) {
     super(reactContext);
-    prefsStorage = new PrefsStorage(reactContext);
+    prefsStorage = new DataStorePrefsStorage(reactContext);
 
     addCipherStorageToMap(new CipherStorageFacebookConceal(reactContext));
     addCipherStorageToMap(new CipherStorageKeystoreAesCbc());
@@ -380,7 +380,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
           cipherStorage.removeKey(alias);
         }
       }
-      // And then we remove the entry in the shared preferences
+      // And then we remove the entry in the preferences
       prefsStorage.removeEntry(alias);
 
       promise.resolve(true);

--- a/android/src/main/java/com/dorianmazur/keychain/PrefsStorage.java
+++ b/android/src/main/java/com/dorianmazur/keychain/PrefsStorage.java
@@ -1,157 +1,59 @@
 package com.dorianmazur.keychain;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.util.Base64;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.facebook.react.bridge.ReactApplicationContext;
-import com.dorianmazur.keychain.KeychainModule.KnownCiphers;
 import com.dorianmazur.keychain.cipherStorage.CipherStorage;
-import com.dorianmazur.keychain.cipherStorage.CipherStorage.EncryptionResult;
 
-import java.util.HashSet;
 import java.util.Set;
 
-@SuppressWarnings({"unused", "WeakerAccess"})
-public class PrefsStorage {
-  public static final String KEYCHAIN_DATA = "RN_KEYCHAIN";
+public interface PrefsStorage {
+  String KEYCHAIN_DATA = "RN_KEYCHAIN";
 
-  static public class ResultSet extends CipherStorage.CipherResult<byte[]> {
-    @KnownCiphers
+  class ResultSet extends CipherStorage.CipherResult<byte[]> {
+    @KeychainModule.KnownCiphers
     public final String cipherStorageName;
 
-    public ResultSet(@KnownCiphers final String cipherStorageName, final byte[] usernameBytes, final byte[] passwordBytes) {
+    public ResultSet(@KeychainModule.KnownCiphers final String cipherStorageName, final byte[] usernameBytes, final byte[] passwordBytes) {
       super(usernameBytes, passwordBytes);
 
       this.cipherStorageName = cipherStorageName;
     }
   }
 
-  @NonNull
-  private final SharedPreferences prefs;
-
-  public PrefsStorage(@NonNull final ReactApplicationContext reactContext) {
-    this.prefs = reactContext.getSharedPreferences(KEYCHAIN_DATA, Context.MODE_PRIVATE);
-  }
-
   @Nullable
-  public ResultSet getEncryptedEntry(@NonNull final String service) {
-    byte[] bytesForUsername = getBytesForUsername(service);
-    byte[] bytesForPassword = getBytesForPassword(service);
-    String cipherStorageName = getCipherStorageName(service);
+  ResultSet getEncryptedEntry(@NonNull final String service);
 
-    // in case of wrong password or username
-    if (bytesForUsername == null || bytesForPassword == null) {
-      return null;
-    }
+  void removeEntry(@NonNull final String service);
 
-    if (cipherStorageName == null) {
-      // If the CipherStorage name is not found, we assume it is because the entry was written by an older
-      // version of this library. The older version used Facebook Conceal, so we default to that.
-      cipherStorageName = KnownCiphers.FB;
-    }
-
-    return new ResultSet(cipherStorageName, bytesForUsername, bytesForPassword);
-
-  }
-
-  public void removeEntry(@NonNull final String service) {
-    final String keyForUsername = getKeyForUsername(service);
-    final String keyForPassword = getKeyForPassword(service);
-    final String keyForCipherStorage = getKeyForCipherStorage(service);
-
-    prefs.edit()
-      .remove(keyForUsername)
-      .remove(keyForPassword)
-      .remove(keyForCipherStorage)
-      .apply();
-  }
-
-  public void storeEncryptedEntry(@NonNull final String service, @NonNull final EncryptionResult encryptionResult) {
-    final String keyForUsername = getKeyForUsername(service);
-    final String keyForPassword = getKeyForPassword(service);
-    final String keyForCipherStorage = getKeyForCipherStorage(service);
-
-    prefs.edit()
-      .putString(keyForUsername, Base64.encodeToString(encryptionResult.username, Base64.DEFAULT))
-      .putString(keyForPassword, Base64.encodeToString(encryptionResult.password, Base64.DEFAULT))
-      .putString(keyForCipherStorage, encryptionResult.cipherName)
-      .apply();
-  }
+  void storeEncryptedEntry(@NonNull final String service, @NonNull final CipherStorage.EncryptionResult encryptionResult);
 
   /**
    * List all types of cipher which are involved in en/decryption of the data stored herein.
-   *
    * A cipher type is stored together with the datum upon encryption so the datum can later be decrypted using correct
-   * cipher. This way, a {@link PrefsStorage} can involve different ciphers for different data. This method returns all
+   * cipher. This way, a [PrefsStorageBase] can involve different ciphers for different data. This method returns all
    * ciphers involved with this storage.
    *
    * @return set of cipher names
    */
-  public Set<String> getUsedCipherNames() {
-    Set<String> result = new HashSet<>();
-
-    Set<String> keys = prefs.getAll().keySet();
-    for (String key : keys) {
-      if (isKeyForCipherStorage(key)) {
-        String cipher = prefs.getString(key, null);
-        result.add(cipher);
-      }
-    }
-
-    return result;
-  }
-
-  @Nullable
-  private byte[] getBytesForUsername(@NonNull final String service) {
-    final String key = getKeyForUsername(service);
-
-    return getBytes(key);
-  }
-
-  @Nullable
-  private byte[] getBytesForPassword(@NonNull final String service) {
-    String key = getKeyForPassword(service);
-    return getBytes(key);
-  }
-
-  @Nullable
-  private String getCipherStorageName(@NonNull final String service) {
-    String key = getKeyForCipherStorage(service);
-
-    return this.prefs.getString(key, null);
-  }
+  Set<String> getUsedCipherNames();
 
   @NonNull
-  public static String getKeyForUsername(@NonNull final String service) {
+  static String getKeyForUsername(@NonNull final String service) {
     return service + ":" + "u";
   }
 
   @NonNull
-  public static String getKeyForPassword(@NonNull final String service) {
+  static String getKeyForPassword(@NonNull final String service) {
     return service + ":" + "p";
   }
 
   @NonNull
-  public static String getKeyForCipherStorage(@NonNull final String service) {
+  static String getKeyForCipherStorage(@NonNull final String service) {
     return service + ":" + "c";
   }
 
-  public static boolean isKeyForCipherStorage(@NonNull final String key) {
+  static boolean isKeyForCipherStorage(@NonNull final String key) {
     return key.endsWith(":c");
-  }
-
-  @Nullable
-  private byte[] getBytes(@NonNull final String key) {
-    String value = this.prefs.getString(key, null);
-
-    if (value != null) {
-      return Base64.decode(value, Base64.DEFAULT);
-    }
-
-    return null;
   }
 }


### PR DESCRIPTION
This implementation is based on the work by @ovitrif in [PR #629](https://github.com/oblador/react-native-keychain/pull/629)

----

## Why
Google is recommending in their official documentation to migrate to `DataStore` from `SharedPreferences`, and they also provided a very easy-to-use auto-migration tool that will move the data to the new `DataStore`, then clean up the entries from `SharedPreferences`.

Their official guide for [saving simple data with SharedPreferences](https://developer.android.com/training/data-storage/shared-preferences).
For security concerns as well, it is recommended to migrate to DataStore.

## How
Since `DataStore` APIs are tailored for Kotlin, the code for using it is also done in Kotlin, thus introducing Kotlin to the project.

Calls to read and write to DataStore are forced to run synchronously based on the example provided by the Android team in [Use DataStore in synchronous code](https://developer.android.com/topic/libraries/architecture/datastore#synchronous).

### Data Migration
[`SharedPreferencesMigration`](https://developer.android.com/reference/kotlin/androidx/datastore/migrations/SharedPreferencesMigration) is used to migrate the entries stored in the `RN_KEYCHAIN` shared prefs file to data store. Upon completion, the `SharedPreferences` get removed.

